### PR TITLE
Added ability to use custom word lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,47 @@ use ClaudioDekker\WordGenerator\Generator;
 echo Generator::generate('-'); // Outputs 'autumn-firefly', 'crimson-meadow', etc.
 ```
 
+### Custom Word Lists
+
+It is also possible to override the adjectives and nouns that can be used to generate the random phrases. For example, you may wish to do this if you want to use words that are themed or branded to your project.
+
+To override the adjectives and nouns at the same time, you can pass an array of strings for both the first and second parameter:
+
+```php
+<?php
+
+use ClaudioDekker\WordGenerator\Generator;
+
+$adjectives = ['adjective one', 'adjective two'];
+$nouns = ['noun one', 'noun two'];
+
+Generator::setWordLists($adjectives, $nouns);
+```
+
+If you only wish to override the adjectives, you can use the following:
+
+```php
+<?php
+
+use ClaudioDekker\WordGenerator\Words\Adjective;
+
+$adjectives = ['adjective one', 'adjective two'];
+
+Adjective::setWordList($adjectives);
+```
+
+If you only wish to override the nouns, you can use the following:
+
+```php
+<?php
+
+use ClaudioDekker\WordGenerator\Words\Noun;
+
+$nouns = ['noun one', 'noun two'];
+
+Noun::setWordList($nouns);
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,6 +8,20 @@ use ClaudioDekker\WordGenerator\Words\Noun;
 class Generator
 {
     /**
+     * Override the adjectives and nouns that should be used when
+     * generating random phrases.
+     *
+     * @param string[] $adjectives
+     * @param string[] $nouns
+     * @return void
+     */
+    public static function setWordLists(array $adjectives, array $nouns): void
+    {
+        Adjective::setWordList($adjectives);
+        Noun::setWordList($nouns);
+    }
+
+    /**
      * Generate a random phrase.
      *
      * @param  string  $separator

--- a/src/Words/Adjective.php
+++ b/src/Words/Adjective.php
@@ -29,4 +29,15 @@ class Adjective
     {
         return self::$adjectives[array_rand(self::$adjectives)];
     }
+
+    /**
+     * Set the possible adjectives that can be returned.
+     *
+     * @param string[] $adjectives
+     * @return void
+     */
+    public static function setWordList(array $adjectives): void
+    {
+        self::$adjectives = $adjectives;
+    }
 }

--- a/src/Words/Noun.php
+++ b/src/Words/Noun.php
@@ -29,4 +29,15 @@ class Noun
     {
         return self::$nouns[array_rand(self::$nouns)];
     }
+
+    /**
+     * Set the possible nouns that can be returned.
+     *
+     * @param string[] $nouns
+     * @return void
+     */
+    public static function setWordList(array $nouns): void
+    {
+        self::$nouns = $nouns;
+    }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -46,4 +46,15 @@ class GeneratorTest extends TestCase
 
         $this->assertNotSame($wordA, $wordB);
     }
+
+    /** @test */
+    public function it_can_use_custom_word_lists(): void
+    {
+        $adjectives = ['foo'];
+        $nouns = ['bar'];
+
+        Generator::setWordLists($adjectives, $nouns);
+
+        $this->assertSame('foo bar', Generator::generate());
+    }
 }


### PR DESCRIPTION
Hey Claudio!

This is a cool package and I've had to do things similar to this in past projects, so I can definitely see this being a useful little tool in the future for me.

This PR adds the ability for the adjectives and/or nouns to be overridden. The idea behind this is that a dev might want to use words that are specifically branded or themed towards their project. As a really basic example, if the project was space-themed, they might only want space-themed phrases such as "fast astronaut".

Another use case could be to load a specific set of adjectives and nouns depending on the user's language. For example, using an English word list for English-speaking users and a Spanish word list for Spanish-speaking users.

Here's a quick example of how you could update your adjectives and nouns at the same time:

```php
use ClaudioDekker\WordGenerator\Generator;

$adjectives = ['adjective one', 'adjective two'];
$nouns = ['noun one', 'noun two'];

Generator::setWordLists($adjectives, $nouns);
```

Or, if you only wanted to update the adjectives or nouns, you could use either of these methods:


```php
use ClaudioDekker\WordGenerator\Words\Adjective;

$adjectives = ['adjective one', 'adjective two'];

Adjective::setWordList($adjectives);
```

```php
use ClaudioDekker\WordGenerator\Words\Noun;

$nouns = ['noun one', 'noun two'];

Noun::setWordList($nouns);
```

In the context of a Laravel app, here are some basic examples of how the wordlists could be overridden using values from config files or from the DB:

```php
Generator::setWordLists(config('wordlists.adjectives'), config('wordlists.nouns'));
```

```php
Adjective::setWordList(
    App\Models\Wordlist::where('type', 'adjective')->pluck('word')->toArray()
);
```

If this is something that you think might be useful for other devs, please let me know if there's anything that you might need me to update for you to get it ready for merging 😄