### PR TITLE
Add ability to reset custom word lists

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,12 +8,12 @@ use ClaudioDekker\WordGenerator\Words\Noun;
 class Generator
 {
     /**
-     * @return void
+     * Reset the adjectives and nouns to their original word lists.
      */
-    public static function init(): void
+    public static function reset(): void
     {
-        Adjective::setWordList([]);
-        Noun::setWordList([]);
+        Adjective::setWordList();
+        Noun::setWordList();
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,6 +8,15 @@ use ClaudioDekker\WordGenerator\Words\Noun;
 class Generator
 {
     /**
+     * @return void
+     */
+    public static function init(): void
+    {
+        Adjective::setWordList([]);
+        Noun::setWordList([]);
+    }
+
+    /**
      * Override the adjectives and nouns that should be used when
      * generating random phrases.
      *

--- a/src/Words/Adjective.php
+++ b/src/Words/Adjective.php
@@ -5,11 +5,11 @@ namespace ClaudioDekker\WordGenerator\Words;
 class Adjective
 {
     /**
-     * A list of adjectives.
+     * The default list of adjectives.
      *
      * @var string[]
      */
-    const DEFAULT_ADJECTIVES = [
+    protected const DEFAULT_ADJECTIVES = [
         'aged', 'ancient', 'autumn', 'billowing', 'bitter', 'blue', 'bold', 'broken',
         'cold', 'cool', 'crimson', 'damp', 'dark', 'dawn', 'delicate', 'divine', 'dry',
         'empty', 'falling', 'floral', 'fragrant', 'frosty', 'green', 'hidden', 'hollow',
@@ -20,7 +20,11 @@ class Adjective
         'weathered', 'wild', 'winter', 'wispy', 'withered', 'young',
     ];
 
-    /** @var array  */
+    /**
+     * The currently configured adjectives.
+     *
+     * @var string[]
+     */
     protected static $adjectives = [];
 
     /**
@@ -28,7 +32,7 @@ class Adjective
      */
     public static function random(): string
     {
-        if(empty(self::$adjectives)) {
+        if (empty(self::$adjectives)) {
             self::setWordList(self::DEFAULT_ADJECTIVES);
         }
 
@@ -40,7 +44,7 @@ class Adjective
      *
      * @param  string[]  $adjectives
      */
-    public static function setWordList(array $adjectives): void
+    public static function setWordList(array $adjectives = []): void
     {
         self::$adjectives = $adjectives;
     }

--- a/src/Words/Adjective.php
+++ b/src/Words/Adjective.php
@@ -9,7 +9,7 @@ class Adjective
      *
      * @var string[]
      */
-    protected static $adjectives = [
+    const DEFAULT_ADJECTIVES = [
         'aged', 'ancient', 'autumn', 'billowing', 'bitter', 'blue', 'bold', 'broken',
         'cold', 'cool', 'crimson', 'damp', 'dark', 'dawn', 'delicate', 'divine', 'dry',
         'empty', 'falling', 'floral', 'fragrant', 'frosty', 'green', 'hidden', 'hollow',
@@ -20,11 +20,18 @@ class Adjective
         'weathered', 'wild', 'winter', 'wispy', 'withered', 'young',
     ];
 
+    /** @var array  */
+    protected static $adjectives = [];
+
     /**
      * Get a random adjective.
      */
     public static function random(): string
     {
+        if(empty(self::$adjectives)) {
+            self::setWordList(self::DEFAULT_ADJECTIVES);
+        }
+
         return self::$adjectives[array_rand(self::$adjectives)];
     }
 

--- a/src/Words/Noun.php
+++ b/src/Words/Noun.php
@@ -9,7 +9,7 @@ class Noun
      *
      * @var string[]
      */
-    protected static $nouns = [
+    const DEFAULT_NOUNS = [
         'bird', 'breeze', 'brook', 'bush', 'butterfly', 'cherry', 'cloud', 'darkness',
         'dawn', 'dew', 'dream', 'dust', 'feather', 'field', 'fire', 'firefly', 'flower',
         'fog', 'forest', 'frog', 'frost', 'galaxy', 'glade', 'glitter', 'grass', 'haze',
@@ -20,11 +20,18 @@ class Noun
         'voice', 'water', 'waterfall', 'wave', 'wildflower', 'willow', 'wind', 'wood',
     ];
 
+    /** @var array  */
+    protected static $nouns = [];
+
     /**
      * Get a random noun.
      */
     public static function random(): string
     {
+        if(empty(self::$nouns)) {
+            self::setWordList(self::DEFAULT_NOUNS);
+        }
+
         return self::$nouns[array_rand(self::$nouns)];
     }
 

--- a/src/Words/Noun.php
+++ b/src/Words/Noun.php
@@ -5,11 +5,11 @@ namespace ClaudioDekker\WordGenerator\Words;
 class Noun
 {
     /**
-     * A list of nouns.
+     * The default list of nouns.
      *
      * @var string[]
      */
-    const DEFAULT_NOUNS = [
+    protected const DEFAULT_NOUNS = [
         'bird', 'breeze', 'brook', 'bush', 'butterfly', 'cherry', 'cloud', 'darkness',
         'dawn', 'dew', 'dream', 'dust', 'feather', 'field', 'fire', 'firefly', 'flower',
         'fog', 'forest', 'frog', 'frost', 'galaxy', 'glade', 'glitter', 'grass', 'haze',
@@ -20,7 +20,11 @@ class Noun
         'voice', 'water', 'waterfall', 'wave', 'wildflower', 'willow', 'wind', 'wood',
     ];
 
-    /** @var array  */
+    /**
+     * The currently configured nouns.
+     *
+     * @var string[]
+     */
     protected static $nouns = [];
 
     /**
@@ -28,7 +32,7 @@ class Noun
      */
     public static function random(): string
     {
-        if(empty(self::$nouns)) {
+        if (empty(self::$nouns)) {
             self::setWordList(self::DEFAULT_NOUNS);
         }
 
@@ -40,7 +44,7 @@ class Noun
      *
      * @param  string[]  $nouns
      */
-    public static function setWordList(array $nouns): void
+    public static function setWordList(array $nouns = []): void
     {
         self::$nouns = $nouns;
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -50,19 +50,17 @@ class GeneratorTest extends TestCase
     /** @test */
     public function it_can_use_custom_word_lists(): void
     {
-        $adjectives = ['foo'];
-        $nouns = ['bar'];
-
-        Generator::setWordLists($adjectives, $nouns);
+        Generator::setWordLists(['foo'], ['bar']);
 
         $this->assertSame('foo bar', Generator::generate());
     }
 
     /** @test */
-    public function it_can_be_reinitialized(): void
+    public function it_can_reset_the_custom_word_lists(): void
     {
         Generator::setWordLists(['foo'], ['bar']);
-        Generator::init();
+
+        Generator::reset();
 
         $this->assertNotSame('foo bar', Generator::generate());
     }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -57,4 +57,13 @@ class GeneratorTest extends TestCase
 
         $this->assertSame('foo bar', Generator::generate());
     }
+
+    /** @test */
+    public function it_can_be_reinitialized(): void
+    {
+        Generator::setWordLists(['foo'], ['bar']);
+        Generator::init();
+
+        $this->assertNotSame('foo bar', Generator::generate());
+    }
 }


### PR DESCRIPTION
added init() method to Generator to reset Adjective and Noun list to a "default" configuration.

This will mostly be helpful for testing.